### PR TITLE
Update dismiss alert dialog

### DIFF
--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/StfalconImageViewer.java
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/StfalconImageViewer.java
@@ -75,6 +75,13 @@ public class StfalconImageViewer<T> {
     }
 
     /**
+     * Dismisses the alert dialog
+     */
+    public void dismissDialog() {
+        dialog.dismiss();
+    }
+
+    /**
      * Updates an existing images list if a new list is not empty, otherwise closes the viewer
      */
     public void updateImages(T[] images) {

--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/dialog/ImageViewerDialog.kt
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/dialog/ImageViewerDialog.kt
@@ -61,6 +61,10 @@ internal class ImageViewerDialog<T>(
         viewerView.close()
     }
 
+    fun dismiss() {
+        dialog.dismiss()
+    }
+
     fun updateImages(images: List<T>) {
         viewerView.updateImages(images)
     }


### PR DESCRIPTION
In order to prevent a WindowLeaked exception when rotating the screen, the AlertDialog should be dismissed when the calling activity enters in onPause. 

Added a "dismissDialog" function in order to programatically dismiss the AlertDialog.