### PR TITLE
Don't intercept volume key presses

### DIFF
--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/dialog/ImageViewerDialog.kt
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/dialog/ImageViewerDialog.kt
@@ -82,8 +82,9 @@ internal class ImageViewerDialog<T>(
             } else {
                 viewerView.close()
             }
+            return true
         }
-        return true
+        return false
     }
 
     private fun setupViewerView() {


### PR DESCRIPTION
I've found that when the image viewer is open, it intercepts volume button keypress events and so prevents the user from adjusting their phone volume. This small fix ensures that only back button presses are intercepted, and volume key presses are passed up to the system.