### PR TITLE
Ensure backgroundView alpha is set to 1 if fade-in animation isn't run

### DIFF
--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/view/ImageViewerView.kt
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/view/ImageViewerView.kt
@@ -256,6 +256,7 @@ internal class ImageViewerView<T> @JvmOverloads constructor(
     }
 
     private fun prepareViewsForViewer() {
+        backgroundView.alpha = 1f
         transitionImageContainer.makeGone()
         imagesPager.makeVisible()
     }


### PR DESCRIPTION
At the end of `ImageViewerView.open()`, the function will call either `animateOpen()` or `prepareViewsForViewer()`. `animateOpen()` will cause the `backgroundView` alpha to be animated from 0 to 1, and then calls `prepareViewsForViewer()`.

The recent commit "Fix background blink on viewer opening" set `backgroundView`'s initial alpha to 0. In the case where the fade-in animation is not run (e.g. by calling `StfalconImageViewer.Builder.show(false)` or by not calling the Builder's `withTransitionFrom()`, which causes `animateOpen()` to not run the fade-in animation), the alpha will not be changed from its initial 0, and the background will not be displayed at all.

This commit sets the `backgroundView` alpha to 1 in `prepareViewsForViewer()`. In the case where the fade-in animation is not run, this ensures the background is visible. In the case where the animation is run, the animation will complete before `prepareViewsForViewer()` is called, the alpha will already be 1, and this additional set should have no effect.

The incorrect behavior with `.show(false)` can be seen in the demo app in the "Rotation support" module when rotating the screen. This should also resolve #27 .