### PR TITLE
Fix translucent navbar for Android 10

### DIFF
--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/dialog/ImageViewerDialog.kt
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/dialog/ImageViewerDialog.kt
@@ -18,6 +18,8 @@ package com.stfalcon.imageviewer.viewer.dialog
 
 import android.content.Context
 import android.view.KeyEvent
+import android.view.View
+import android.view.WindowManager
 import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
 import com.stfalcon.imageviewer.R
@@ -39,6 +41,12 @@ internal class ImageViewerDialog<T>(
         else
             R.style.ImageViewerDialog_Default
 
+    private val dialogSystemUiVisibility: Int
+        get() = if (builderData.shouldStatusBarHide)
+            0
+        else
+            View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+
     init {
         setupViewerView()
         dialog = AlertDialog
@@ -50,6 +58,7 @@ internal class ImageViewerDialog<T>(
                 setOnShowListener { viewerView.open(builderData.transitionView, animateOpen) }
                 setOnDismissListener { builderData.onDismissListener?.onDismiss() }
             }
+        dialog.window?.decorView?.systemUiVisibility = dialogSystemUiVisibility
     }
 
     fun show(animate: Boolean) {

--- a/imageviewer/src/main/res/values-v29/styles.xml
+++ b/imageviewer/src/main/res/values-v29/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    
+    <style name="ImageViewerDialog.Default" parent="ImageViewerDialog.DefaultBaseTheme">
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
+    
+</resources>

--- a/imageviewer/src/main/res/values/styles.xml
+++ b/imageviewer/src/main/res/values/styles.xml
@@ -5,8 +5,11 @@
 
     <style name="ImageViewerDialog.NoStatusBar" parent="android:Theme.Translucent.NoTitleBar.Fullscreen"/>
 
-    <style name="ImageViewerDialog.Default" parent="android:Theme.Translucent.NoTitleBar">
+    <style name="ImageViewerDialog.DefaultBaseTheme" parent="android:Theme.Translucent.NoTitleBar">
         <item name="android:windowTranslucentStatus">true</item>
+    </style>
+    
+    <style name="ImageViewerDialog.Default" parent="ImageViewerDialog.DefaultBaseTheme">
         <item name="android:windowTranslucentNavigation">true</item>
     </style>
 


### PR DESCRIPTION
When the status bar is _not_ hidden (i.e. `StfalconImageViewer.Builder().withHiddenStatusBar(false)`), past behavior was for the
navigation bar to be translucent. On Android 10 (SDK 29), it is opaque
black. See screenshot below, Android 9 on left and Android 10 on right

![Screenshot from 2020-02-22 13-25-45](https://user-images.githubusercontent.com/23462789/75100128-251fac00-5587-11ea-98fc-8647ee968bc1.png)

This patch restores and improves upon past behavior for Android 10 by
ensuring a fully transparent nav bar when gesture controls are enabled
(and using the system-provided translucent scrim when 3-button navigation
is enabled). See screenshot below, Android 9 on left,
Android 10 center and right with three-button and gesture navigation.

![Screenshot from 2020-02-22 15-25-23](https://user-images.githubusercontent.com/23462789/75100194-edfdca80-5587-11ea-821f-4305b29f45ee.png)

I'm not 100% sure I've done this in the optimal way, but here's what I've found:

To achieve this we need to switch from using
android:windowTranslucentNavigation to using android:navigationBarColor.
On Android 10, it appears android:windowDrawsSystemBarBackgrounds
must be set for android:navigationBarColor to have any affect.
(I wonder if this is related to using an AlertDialog.)
android:windowDrawsSystemBarBackgrounds is not supported in SDK < 21,
whereas this library supports SDK >= 19, so I've created a separate
styles.xml file for SDK >= 29.

Setting systemUiVisibility flags appears to be necessary to get
the transparent nav bar effect. It seems that setting
android:windowTranslucentNavigation was providing the same effect
as setting these flags, but now it needs to be done manually for
SDK >= 29 as android:windowTranslucentNavigation is not set.