### PR TITLE
Add 'Image Full Focus'

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ For setting a padding in pixels, just use the `withContainerPadding(...)` method
 #### Status bar visibility
 Control the status bar visibility of the opened viewer by using the `withHiddenStatusBar(boolean)` method (`true` by default)
 
+#### Image full focus
+Hide everything but the image when interacting with the image by using the `withImageFullFocusEnabled(boolean)` method (`false` by default)
+
 #### Gestures
 If you need to disable some of the gestures - you can use the `allowSwipeToDismiss(boolean)` and `allowZooming(boolean)` methods accordingly.
 
@@ -107,6 +110,7 @@ StfalconImageViewer.Builder<String>(this, images, ::loadImage)
             .allowZooming(isZoomingAllowed)
             .allowSwipeToDismiss(isSwipeToDismissAllowed)
             .withTransitionFrom(targeImageView)
+            .withImageFullFocusEnabled(true)
             .withImageChangeListener(::onImageChanged)
             .withDismissListener(::onViewerDismissed)
             .withDismissListener(::onViewerDismissed)

--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/StfalconImageViewer.java
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/StfalconImageViewer.java
@@ -162,6 +162,18 @@ public class StfalconImageViewer<T> {
         }
 
         /**
+         * Sets image full focus enabled or disabled. When full focus is enabled, tapping to hide
+         * the overlay, zooming or double tapping will also hide the status bar, navigation bar
+         * and set the background to black so the only thing visible is the image.
+         *
+         * @return This Builder object to allow calls chaining
+         */
+        public Builder<T> withImageFullFocusEnabled(boolean enabled) {
+            this.data.setImageFullFocusEnabled(enabled);
+            return this;
+        }
+
+        /**
          * Sets custom overlay view to be shown over the viewer.
          * Commonly used for image description or counter displaying.
          *

--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/builder/BuilderData.kt
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/builder/BuilderData.kt
@@ -38,4 +38,5 @@ internal class BuilderData<T>(
     var isZoomingAllowed = true
     var isSwipeToDismissAllowed = true
     var transitionView: ImageView? = null
+    var imageFullFocusEnabled = false
 }

--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/dialog/ImageViewerDialog.kt
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/dialog/ImageViewerDialog.kt
@@ -104,6 +104,7 @@ internal class ImageViewerDialog<T>(
             containerPadding = builderData.containerPaddingPixels
             imagesMargin = builderData.imageMarginPixels
             overlayView = builderData.overlayView
+            imageFullFocusEnabled = builderData.imageFullFocusEnabled
 
             setBackgroundColor(builderData.backgroundColor)
             setImages(builderData.images, builderData.startPosition, builderData.imageLoader)


### PR DESCRIPTION
Hide everything but the image when interacting with the image by using the `withImageFullFocusEnabled(boolean)` method (`false` by default).
Added functionality, builder and README.