### PR TITLE
Overload setCurrentPosition() to allow disabling the scroll animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you need more advanced behavior like updating transition target while changin
 There are a lot of common cases (such as pagination, deleting, editing etc.) where you need to update the existing images list while the viewer is running. To do this you can simply update the existing list (or even replace it with a new one) and then call `updateImages(images)`.
 
 #### Change current image
-Images are not always leafed through by the user. Maybe you want to implement some kind of preview list at the bottom of the viewer - `setCurrentPosition` is here for help. Change images programmatically wherever you want!
+Images are not always leafed through by the user. Maybe you want to implement some kind of preview list at the bottom of the viewer - `setCurrentPosition` is here for help. Change images programmatically wherever you want! Set the optional second argument to false to disable the scroll animation while the image changes.
 
 #### Custom overlay view
 If you need to show some content over the image (e.g. sharing or download button, description, numeration etc.) you can set your own custom view using the `setOverlayView(customView)` and bind it with the viewer through the `ImageViewer.OnImageChangeListener`.

--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/StfalconImageViewer.java
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/StfalconImageViewer.java
@@ -103,8 +103,12 @@ public class StfalconImageViewer<T> {
         return dialog.getCurrentPosition();
     }
 
-    public int setCurrentPosition(int position){
-        return dialog.setCurrentPosition(position);
+    public int setCurrentPosition(int position, boolean smoothScroll) {
+        return dialog.setCurrentPosition(position, smoothScroll);
+    }
+    
+    public int setCurrentPosition(int position) {
+        return setCurrentPosition(position, true);
     }
 
     /**

--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/dialog/ImageViewerDialog.kt
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/dialog/ImageViewerDialog.kt
@@ -72,8 +72,8 @@ internal class ImageViewerDialog<T>(
     fun getCurrentPosition(): Int =
         viewerView.currentPosition
 
-    fun setCurrentPosition(position: Int): Int {
-        viewerView.currentPosition = position
+    fun setCurrentPosition(position: Int, smoothScroll: Boolean): Int {
+        viewerView.setCurrentPosition(position, smoothScroll)
         return viewerView.currentPosition
     }
 

--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/view/ImageViewerView.kt
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/view/ImageViewerView.kt
@@ -64,6 +64,10 @@ internal class ImageViewerView<T> @JvmOverloads constructor(
             imagesPager.currentItem = value
         }
 
+    fun setCurrentPosition(position: Int, smoothScroll: Boolean) {
+        imagesPager.setCurrentItem(position, smoothScroll)
+    }
+
     internal var onDismiss: (() -> Unit)? = null
     internal var onPageChange: ((position: Int) -> Unit)? = null
 


### PR DESCRIPTION
Here's another PR for when you get a chance to poke at this library some more. I have a use case that benefits from the setCurrentPosition() method that was added in 1.0.0, but this use case also looks nicer if there's no animation when the viewer changes the image being displayed. (The image is changed when returning from an activity that was launched while viewing an image.) In case it's useful to others, here's my patch to add an optional second argument to setCurrentPosition which controls the smooth scroll animation (`true`=animation, `false`=no animation). The one-argument form continues to use the animation, so there's no change to existing code using the library. The value of that second argument is passed through to the two-argument form of setCurrentItem in the androidx ViewPager that MultiTouchViewPager extends.