### PR TITLE
Add ability to change dialog style to allow alert dialog customizations

### DIFF
--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/StfalconImageViewer.java
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/StfalconImageViewer.java
@@ -17,6 +17,7 @@
 package com.stfalcon.imageviewer;
 
 import android.content.Context;
+import android.os.*;
 import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
@@ -245,6 +246,28 @@ public class StfalconImageViewer<T> {
          */
         public Builder<T> withHiddenStatusBar(boolean value) {
             this.data.setShouldStatusBarHide(value);
+            return this;
+        }
+
+        /**
+         * Sets alert dialog style. ImageViewerDialog.Default by default.
+         *
+         * @return This Builder object to allow calls chaining
+         */
+        public Builder<T> withDialogStyle(int value) {
+            this.data.setDialogStyle(value);
+            return this;
+        }
+
+        /**
+         * Sets status bar transparency to allow drawing underneath it. False by default.
+         * Works only on API 21 and above.
+         *
+         * @return This Builder object to allow calls chaining
+         */
+        @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+        public Builder<T> shouldStatusBarTransparent(boolean value) {
+            this.data.setShouldStatusBarTransparent(value);
             return this;
         }
 

--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/builder/BuilderData.kt
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/builder/BuilderData.kt
@@ -19,6 +19,7 @@ package com.stfalcon.imageviewer.viewer.builder
 import android.graphics.Color
 import android.view.View
 import android.widget.ImageView
+import com.stfalcon.imageviewer.R
 import com.stfalcon.imageviewer.listeners.OnDismissListener
 import com.stfalcon.imageviewer.listeners.OnImageChangeListener
 import com.stfalcon.imageviewer.loader.ImageLoader
@@ -35,7 +36,9 @@ internal class BuilderData<T>(
     var imageMarginPixels: Int = 0
     var containerPaddingPixels = IntArray(4)
     var shouldStatusBarHide = true
+    var shouldStatusBarTransparent = false
     var isZoomingAllowed = true
     var isSwipeToDismissAllowed = true
     var transitionView: ImageView? = null
+    var dialogStyle: Int = R.style.ImageViewerDialog_Default
 }

--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/dialog/ImageViewerDialog.kt
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/dialog/ImageViewerDialog.kt
@@ -17,7 +17,9 @@
 package com.stfalcon.imageviewer.viewer.dialog
 
 import android.content.Context
+import android.os.Build
 import android.view.KeyEvent
+import android.view.WindowManager
 import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
 import com.stfalcon.imageviewer.R
@@ -37,7 +39,7 @@ internal class ImageViewerDialog<T>(
         get() = if (builderData.shouldStatusBarHide)
             R.style.ImageViewerDialog_NoStatusBar
         else
-            R.style.ImageViewerDialog_Default
+            builderData.dialogStyle
 
     init {
         setupViewerView()
@@ -50,6 +52,11 @@ internal class ImageViewerDialog<T>(
                 setOnShowListener { viewerView.open(builderData.transitionView, animateOpen) }
                 setOnDismissListener { builderData.onDismissListener?.onDismiss() }
             }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (builderData.shouldStatusBarTransparent) {
+                dialog.window?.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+            }
+        }
     }
 
     fun show(animate: Boolean) {


### PR DESCRIPTION
This allows the ability to change alert dialog style and also provides the ability
to set status bar color. Can even be set to transparent to allow and draw behind without
translucency.

### Before: 
<img src="https://user-images.githubusercontent.com/6688825/133327538-8ae5ec2f-4bf8-49d5-ae2e-a79c7b9b1651.jpg" height=300 width=150>

### After: 
<img src="https://user-images.githubusercontent.com/6688825/133327537-13dca4bd-6f50-44bb-b90b-0e55d0fc73e1.jpg" height=300 width=150>

Usage:
```kotlin
  viewer = StfalconImageViewer.Builder<Poster>(this, Demo.posters, ::loadPosterImage)
      .withStartPosition(startPosition)
      .withHiddenStatusBar(false)
      .shouldStatusBarTransparent(true)
      .withDialogStyle(R.style.MyCustomStyle)
      .show()
```
